### PR TITLE
Add checks for watchOS

### DIFF
--- a/Sources/AppleWatchScreenSize/AppleWatchScreenSize.swift
+++ b/Sources/AppleWatchScreenSize/AppleWatchScreenSize.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import WatchKit
 
 /**
@@ -75,3 +76,4 @@ public struct ScreenSize: Hashable {
         return lhs.width == rhs.width && lhs.height == rhs.height
     }
 }
+#endif


### PR DESCRIPTION
I had an issue with SwiftUI Previews and this library. Sometimes the preview would not load because the iPhone app wanted to integrate the library (even though the import was conditional). `#if os(watchOS)` fixed it for me. Great library otherwise.